### PR TITLE
[TEST] 상담 관련 api 테스트 코드 작성

### DIFF
--- a/src/test/java/auctionTalk/auction/domain/counsel/controller/CounselControllerTest.java
+++ b/src/test/java/auctionTalk/auction/domain/counsel/controller/CounselControllerTest.java
@@ -1,0 +1,350 @@
+package auctionTalk.auction.domain.counsel.controller;
+
+import auctionTalk.auction.config.security.auth.PrincipalDetails;
+import auctionTalk.auction.domain.counsel.dto.request.CounselApplyRequest;
+import auctionTalk.auction.domain.counsel.dto.request.CounselFormCreateRequest;
+import auctionTalk.auction.domain.counsel.dto.request.CounselFormUpdateRequest;
+import auctionTalk.auction.domain.counsel.dto.response.*;
+import auctionTalk.auction.domain.counsel.entity.CounselStatus;
+import auctionTalk.auction.domain.counsel.service.CounselService;
+import auctionTalk.auction.domain.member.entity.Member;
+import auctionTalk.auction.domain.member.entity.Role;
+import auctionTalk.auction.global.exception.CustomApiException;
+import auctionTalk.auction.global.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        controllers = CounselController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class,
+                OAuth2ClientAutoConfiguration.class,
+                OAuth2ResourceServerAutoConfiguration.class
+        }
+)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(CounselControllerTest.TestMvcConfig.class)
+class CounselControllerTest {
+
+    @TestConfiguration
+    static class TestMvcConfig implements WebMvcConfigurer {
+        @Override
+        public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+            resolvers.add(new AuthenticationPrincipalArgumentResolver());
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CounselService counselService;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    private ObjectMapper objectMapper;
+    private Member member;
+    private PrincipalDetails principalDetails;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        member = Member.builder()
+                .id(1L)
+                .clientId("test-client-id")
+                .role(Role.USER)
+                .build();
+
+        principalDetails = new PrincipalDetails(member, Map.of());
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        principalDetails, null, principalDetails.getAuthorities()
+                )
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("상담사 매칭 요청이 들어오면 추천 상담사 정보를 응답")
+    void matchCounselor_success() throws Exception {
+        CounselFormCreateRequest request = new CounselFormCreateRequest(
+                "투자 목적", "수도권", "서류 준비", "아파트 경매", "개인"
+        );
+
+        MatchCounselorResponse response = MatchCounselorResponse.builder()
+                .counselorId(1L)
+                .counselorName("테스트 상담사")
+                .score(4.5)
+                .reviewCount(10)
+                .counselCount(50)
+                .description("10년 경력의 상담사입니다.")
+                .build();
+
+        given(counselService.matchCounselor(any(CounselFormCreateRequest.class), any(Member.class)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/counsels/matches")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.counselorId").value(1L))
+                .andExpect(jsonPath("$.result.counselorName").value("테스트 상담사"))
+                .andExpect(jsonPath("$.result.score").value(4.5));
+
+        then(counselService).should().matchCounselor(any(CounselFormCreateRequest.class), any(Member.class));
+    }
+
+    @Test
+    @DisplayName("상담사 매칭 중 비즈니스 예외가 발생하면 실패 응답을 반환")
+    void matchCounselor_fail_serviceThrowsCustomException() throws Exception {
+        CounselFormCreateRequest request = new CounselFormCreateRequest(
+                "투자 목적", "수도권", "서류 준비", "아파트 경매", "개인"
+        );
+
+        given(counselService.matchCounselor(any(CounselFormCreateRequest.class), any(Member.class)))
+                .willThrow(new CustomApiException(ErrorCode.MEMBER_IS_SUBSCRIBED));
+
+        mockMvc.perform(post("/counsels/matches")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
+    @DisplayName("상담 폼 수정 요청이 들어오면 수정된 상담 폼 정보를 응답")
+    void updateCounselForm_success() throws Exception {
+        CounselFormUpdateRequest request = new CounselFormUpdateRequest(
+                "실거주 목적", "서울", "명도까지 전반적으로", "아파트 경매", "법인"
+        );
+
+        CounselUpdateResponse response = CounselUpdateResponse.builder()
+                .counselFormId(1L)
+                .counselorId(1L)
+                .counselorName("테스트 상담사")
+                .score(4.5)
+                .reviewCount(12)
+                .build();
+
+        given(counselService.updateCounselForm(eq(1L), any(CounselFormUpdateRequest.class), any(Member.class)))
+                .willReturn(response);
+
+        mockMvc.perform(patch("/counsels/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.counselFormId").value(1L))
+                .andExpect(jsonPath("$.result.counselorName").value("테스트 상담사"));
+
+        then(counselService).should().updateCounselForm(eq(1L), any(CounselFormUpdateRequest.class), any(Member.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상담 폼 수정 요청이 들어오면 404 응답을 반환")
+    void updateCounselForm_fail_notFound() throws Exception {
+        CounselFormUpdateRequest request = new CounselFormUpdateRequest(
+                "실거주 목적", "서울", "명도까지 전반적으로", "아파트 경매", "법인"
+        );
+
+        given(counselService.updateCounselForm(eq(999L), any(CounselFormUpdateRequest.class), any(Member.class)))
+                .willThrow(new CustomApiException(ErrorCode.COUNSEL_NOT_FOUND));
+
+        mockMvc.perform(patch("/counsels/999")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
+    @DisplayName("상담 신청 요청이 들어오면 생성된 상담 정보를 응답")
+    void applyCounsel_success() throws Exception {
+        CounselFormCreateRequest formRequest = new CounselFormCreateRequest(
+                "투자 목적", "수도권", "서류 준비", "아파트 경매", "개인"
+        );
+
+        CounselApplyRequest request = new CounselApplyRequest(
+                formRequest, LocalDateTime.of(2025, 12, 30, 10, 0)
+        );
+
+        ApplyCounselResponse response = ApplyCounselResponse.builder()
+                .counselId(1L)
+                .counselFormId(1L)
+                .counselDate(LocalDate.of(2025, 12, 30))
+                .counselTime(LocalTime.of(10, 0))
+                .cellPhone("010-1234-5678")
+                .purpose("투자 목적")
+                .area("수도권")
+                .build();
+
+        given(counselService.applyCounsel(any(Member.class), eq(1L), any(CounselApplyRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/counsels/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.counselId").value(1L))
+                .andExpect(jsonPath("$.result.counselFormId").value(1L));
+
+        then(counselService).should().applyCounsel(any(Member.class), eq(1L), any(CounselApplyRequest.class));
+    }
+
+    @Test
+    @DisplayName("상담 일정 변경 요청이 들어오면 변경된 상담 정보를 응답")
+    void updateCounsel_success() throws Exception {
+        ApplyCounselResponse response = ApplyCounselResponse.builder()
+                .counselId(1L)
+                .counselFormId(1L)
+                .counselDate(LocalDate.of(2025, 12, 31))
+                .counselTime(LocalTime.of(14, 0))
+                .build();
+
+        // 컨트롤러는 LocalDateTime 하나를 받아서 내부에서 LocalDate / LocalTime으로 분리하는 구조
+        given(counselService.updateApplyCounsel(
+                anyLong(), anyLong(), any(Member.class), anyLong(),
+                any(LocalDate.class), any(LocalTime.class)
+        )).willReturn(response);
+
+        mockMvc.perform(patch("/counsels/1/update")
+                        .param("counselorId", "1")
+                        .param("counselFormId", "1")
+                        .param("date", "2025-12-31T14:00:00"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.counselId").value(1L));
+    }
+
+    @Test
+    @DisplayName("상담 일정 변경 요청에서 날짜 형식이 잘못되면 400 응답을 반환")
+    void updateCounsel_fail_invalidDateFormat() throws Exception {
+        mockMvc.perform(patch("/counsels/1/update")
+                        .param("counselorId", "1")
+                        .param("counselFormId", "1")
+                        .param("date", "wrong-date"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("상담 가능 시간 조회 시 예약 가능한 시간 목록을 응답")
+    void inquiryPossibleTime_success() throws Exception {
+        List<LocalTime> availableTimes = List.of(
+                LocalTime.of(10, 0),
+                LocalTime.of(10, 30),
+                LocalTime.of(11, 0)
+        );
+
+        given(counselService.inquiryPossibleTime(eq(1L), any(LocalDate.class)))
+                .willReturn(availableTimes);
+
+        mockMvc.perform(get("/counsels/1/times")
+                        .param("date", "2025-12-30"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result").isArray())
+                .andExpect(jsonPath("$.result.length()").value(3));
+    }
+
+    @Test
+    @DisplayName("상담 가능 시간 조회에서 날짜가 누락되면 400 응답을 반환")
+    void inquiryPossibleTime_fail_missingDateParam() throws Exception {
+        mockMvc.perform(get("/counsels/1/times"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("상담 정보가 없으면 NONE 상태를 응답")
+    void getCounselInfo_whenNone() throws Exception {
+        CounselCombinedResponse response = new CounselCombinedResponse(CounselStatus.NONE, null);
+
+        given(counselService.getCounselInfo(any(Member.class))).willReturn(response);
+
+        mockMvc.perform(get("/counsels/info"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.status").value("NONE"));
+    }
+
+    @Test
+    @DisplayName("상담 정보가 있으면 상담 상태와 상세 정보를 함께 응답")
+    void getCounselInfo_success() throws Exception {
+        CounselInfoResponse infoResponse = CounselInfoResponse.builder()
+                .counselId(1L)
+                .counselorId(1L)
+                .counselorName("테스트 상담사")
+                .counselDate(LocalDate.of(2025, 12, 30))
+                .counselTime(LocalTime.of(10, 0))
+                .score(4.5)
+                .reviewCount(2)
+                .build();
+
+        CounselCombinedResponse response = new CounselCombinedResponse(
+                CounselStatus.COUNSEL_AFTER, infoResponse
+        );
+
+        given(counselService.getCounselInfo(any(Member.class))).willReturn(response);
+
+        mockMvc.perform(get("/counsels/info"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.status").value("COUNSEL_AFTER"))
+                .andExpect(jsonPath("$.result.info.counselId").value(1L))
+                .andExpect(jsonPath("$.result.info.counselorName").value("테스트 상담사"))
+                .andExpect(jsonPath("$.result.info.score").value(4.5))
+                .andExpect(jsonPath("$.result.info.reviewCount").value(2));
+    }
+}

--- a/src/test/java/auctionTalk/auction/domain/counsel/service/CounselServiceImplTest.java
+++ b/src/test/java/auctionTalk/auction/domain/counsel/service/CounselServiceImplTest.java
@@ -1,0 +1,511 @@
+package auctionTalk.auction.domain.counsel.service;
+
+import auctionTalk.auction.domain.counsel.dto.request.CounselApplyRequest;
+import auctionTalk.auction.domain.counsel.dto.request.CounselFormCreateRequest;
+import auctionTalk.auction.domain.counsel.dto.request.CounselFormUpdateRequest;
+import auctionTalk.auction.domain.counsel.dto.response.*;
+import auctionTalk.auction.domain.counsel.entity.Counsel;
+import auctionTalk.auction.domain.counsel.entity.CounselForm;
+import auctionTalk.auction.domain.counsel.entity.CounselStatus;
+import auctionTalk.auction.domain.counsel.mapper.CounselMapper;
+import auctionTalk.auction.domain.counsel.repository.CounselFormRepository;
+import auctionTalk.auction.domain.counsel.repository.CounselRepository;
+import auctionTalk.auction.domain.counselor.entity.Counselor;
+import auctionTalk.auction.domain.counselor.repository.CounselorRepository;
+import auctionTalk.auction.domain.member.entity.Member;
+import auctionTalk.auction.domain.member.entity.Role;
+import auctionTalk.auction.domain.review.entity.Review;
+import auctionTalk.auction.domain.review.repository.ReviewRepository;
+import auctionTalk.auction.domain.subscription.entity.SubscriptionStatus;
+import auctionTalk.auction.domain.subscription.repository.SubscriptionRepository;
+import auctionTalk.auction.global.exception.CustomApiException;
+import auctionTalk.auction.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CounselServiceImplTest {
+
+    @InjectMocks
+    private CounselServiceImpl counselService;
+
+    @Mock
+    private CounselMapper counselMapper;
+
+    @Mock
+    private CounselRepository counselRepository;
+
+    @Mock
+    private CounselorRepository counselorRepository;
+
+    @Mock
+    private CounselFormRepository counselFormRepository;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    private Member member;
+    private Counselor counselor;
+    private CounselForm counselForm;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .id(1L)
+                .clientId("test-client-id")
+                .role(Role.USER)
+                .build();
+
+        counselor = Counselor.builder()
+                .id(1L)
+                .name("테스트 상담사")
+                .description("10년 경력의 상담사입니다.")
+                .experience(10)
+                .counselCount(50)
+                .license("경매지도사")
+                .Specialization("아파트 경매")
+                .cellPhone("010-1234-5678")
+                .build();
+
+        counselForm = CounselForm.builder()
+                .id(1L)
+                .member(member)
+                .purpose("투자 목적")
+                .area("수도권")
+                .serviceType("서류 준비")
+                .interest("아파트 경매")
+                .participantType("개인")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("상담사 매칭")
+    class MatchCounselorTest {
+
+        @Test
+        @DisplayName("구독 이력이 없는 사용자는 상담사 매칭 성공")
+        void matchCounselor_success() {
+            CounselFormCreateRequest request = new CounselFormCreateRequest(
+                    "투자 목적", "수도권", "서류 준비", "아파트 경매", "개인"
+            );
+
+            MatchCounselorResponse expectedResponse = MatchCounselorResponse.builder()
+                    .counselorId(1L)
+                    .counselorName("테스트 상담사")
+                    .score(0.0)
+                    .reviewCount(0)
+                    .counselCount(50)
+                    .build();
+
+            given(subscriptionRepository.existsByMemberAndSubscriptionStatus(member, SubscriptionStatus.IN_PROGRESS))
+                    .willReturn(false);
+            given(counselorRepository.getCounselor(1L)).willReturn(counselor);
+            given(reviewRepository.findAllByCounsel_Counselor(counselor)).willReturn(List.of());
+            given(counselMapper.toMatchCounselorResponse(counselor, 0.0, 0)).willReturn(expectedResponse);
+
+            MatchCounselorResponse result = counselService.matchCounselor(request, member);
+
+            assertThat(result).isEqualTo(expectedResponse);
+            assertThat(result.getCounselorId()).isEqualTo(1L);
+            assertThat(result.getCounselorName()).isEqualTo("테스트 상담사");
+
+            then(subscriptionRepository).should()
+                    .existsByMemberAndSubscriptionStatus(member, SubscriptionStatus.IN_PROGRESS);
+            then(counselorRepository).should().getCounselor(1L);
+            then(counselMapper).should().toMatchCounselorResponse(counselor, 0.0, 0);
+        }
+
+        @Test
+        @DisplayName("구독 중인 사용자는 새로운 상담사 매칭을 요청 불가")
+        void matchCounselor_fail_whenMemberIsSubscribed() {
+            CounselFormCreateRequest request = new CounselFormCreateRequest(
+                    "투자 목적", "수도권", "서류 준비", "아파트 경매", "개인"
+            );
+
+            given(subscriptionRepository.existsByMemberAndSubscriptionStatus(member, SubscriptionStatus.IN_PROGRESS))
+                    .willReturn(true);
+
+            assertThatThrownBy(() -> counselService.matchCounselor(request, member))
+                    .isInstanceOf(CustomApiException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.MEMBER_IS_SUBSCRIBED);
+
+            then(counselorRepository).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("상담 폼 수정")
+    class UpdateCounselFormTest {
+
+        @Test
+        @DisplayName("상담 폼 수정 요청이 들어오면 기존 상담 폼 정보가 요청값으로 갱신")
+        void updateCounselForm_success() {
+            Long counselFormId = 1L;
+
+            CounselFormUpdateRequest request = new CounselFormUpdateRequest(
+                    "실거주 목적", "서울", "명도까지 전반적으로", "아파트 경매", "법인"
+            );
+
+            CounselUpdateResponse expectedResponse = CounselUpdateResponse.builder()
+                    .counselFormId(counselFormId)
+                    .counselorId(1L)
+                    .counselorName("테스트 상담사")
+                    .score(0.0)
+                    .reviewCount(0)
+                    .build();
+
+            given(counselorRepository.getCounselor(1L)).willReturn(counselor);
+            given(counselFormRepository.getCounselFormById(counselFormId)).willReturn(counselForm);
+            given(counselFormRepository.save(any(CounselForm.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+            given(reviewRepository.findAllByCounsel_Counselor(counselor)).willReturn(List.of());
+            given(counselMapper.toCounselUpdateResponse(counselor, counselFormId, 0.0, 0))
+                    .willReturn(expectedResponse);
+
+            CounselUpdateResponse result = counselService.updateCounselForm(counselFormId, request, member);
+
+            assertThat(result).isEqualTo(expectedResponse);
+            assertThat(counselForm.getPurpose()).isEqualTo("실거주 목적");
+            assertThat(counselForm.getArea()).isEqualTo("서울");
+            assertThat(counselForm.getServiceType()).isEqualTo("명도까지 전반적으로");
+            assertThat(counselForm.getInterest()).isEqualTo("아파트 경매");
+            assertThat(counselForm.getParticipantType()).isEqualTo("법인");
+
+            then(counselFormRepository).should().save(counselForm);
+            then(counselMapper).should().toCounselUpdateResponse(counselor, counselFormId, 0.0, 0);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상담 폼을 수정하려고 하면 상담 정보를 찾을 수 없다는 예외가 발생")
+        void updateCounselForm_fail_whenCounselFormNotFound() {
+            Long invalidCounselFormId = 999L;
+
+            CounselFormUpdateRequest request = new CounselFormUpdateRequest(
+                    "실거주 목적", "서울", "명도까지 전반적으로", "아파트 경매", "법인"
+            );
+
+            given(counselorRepository.getCounselor(1L)).willReturn(counselor);
+            given(counselFormRepository.getCounselFormById(invalidCounselFormId))
+                    .willThrow(new CustomApiException(ErrorCode.COUNSEL_NOT_FOUND));
+
+            assertThatThrownBy(() -> counselService.updateCounselForm(invalidCounselFormId, request, member))
+                    .isInstanceOf(CustomApiException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.COUNSEL_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("상담 신청")
+    class ApplyCounselTest {
+
+        @Test
+        @DisplayName("상담 신청 시 요청한 날짜와 시간이 분리되어 상담 정보로 저장")
+        void applyCounsel_success() {
+            Long counselorId = 1L;
+            LocalDateTime counselDateTime = LocalDateTime.of(2025, 12, 30, 10, 0);
+            LocalDate expectedDate = counselDateTime.toLocalDate();
+            LocalTime expectedTime = counselDateTime.toLocalTime();
+
+            CounselFormCreateRequest formRequest = new CounselFormCreateRequest(
+                    "투자 목적", "수도권", "서류 준비", "아파트 경매", "개인"
+            );
+            CounselApplyRequest request = new CounselApplyRequest(formRequest, counselDateTime);
+
+            Counsel counsel = Counsel.builder()
+                    .id(1L)
+                    .member(member)
+                    .counselor(counselor)
+                    .counselForm(counselForm)
+                    .counselDate(expectedDate)
+                    .counselTime(expectedTime)
+                    .counselStatus(CounselStatus.COUNSEL_BEFORE)
+                    .build();
+
+            ApplyCounselResponse expectedResponse = ApplyCounselResponse.builder()
+                    .counselId(1L)
+                    .counselFormId(1L)
+                    .counselDate(expectedDate)
+                    .counselTime(expectedTime)
+                    .cellPhone("010-1234-5678")
+                    .build();
+
+            given(counselorRepository.getCounselor(counselorId)).willReturn(counselor);
+            given(counselMapper.toCounselForm(formRequest, member)).willReturn(counselForm);
+            given(counselFormRepository.save(counselForm)).willReturn(counselForm);
+            given(counselMapper.toCounsel(member, counselor, expectedDate, expectedTime, counselForm))
+                    .willReturn(counsel);
+            given(counselRepository.save(counsel)).willReturn(counsel);
+            given(counselMapper.toApplyCounselResponse(1L, counselForm, expectedDate, expectedTime, counselor))
+                    .willReturn(expectedResponse);
+
+            ApplyCounselResponse result = counselService.applyCounsel(member, counselorId, request);
+
+            assertThat(result).isEqualTo(expectedResponse);
+            assertThat(result.getCounselDate()).isEqualTo(expectedDate);
+            assertThat(result.getCounselTime()).isEqualTo(expectedTime);
+
+            then(counselMapper).should().toCounselForm(formRequest, member);
+            then(counselMapper).should().toCounsel(member, counselor, expectedDate, expectedTime, counselForm);
+            then(counselMapper).should()
+                    .toApplyCounselResponse(1L, counselForm, expectedDate, expectedTime, counselor);
+
+            var inOrder = inOrder(counselFormRepository, counselRepository);
+            inOrder.verify(counselFormRepository).save(counselForm);
+            inOrder.verify(counselRepository).save(counsel);
+        }
+    }
+
+    @Nested
+    @DisplayName("상담 일정 변경")
+    class UpdateApplyCounselTest {
+
+        @Test
+        @DisplayName("상담 일정 변경 시 기존 상담의 날짜와 시간이 함께 변경")
+        void updateApplyCounsel_success() {
+            Long counselId = 1L;
+            Long counselFormId = 1L;
+            Long counselorId = 1L;
+            LocalDate newDate = LocalDate.of(2025, 12, 31);
+            LocalTime newTime = LocalTime.of(14, 0);
+
+            Counsel counsel = Counsel.builder()
+                    .id(counselId)
+                    .member(member)
+                    .counselor(counselor)
+                    .counselForm(counselForm)
+                    .counselDate(LocalDate.of(2025, 12, 30))
+                    .counselTime(LocalTime.of(10, 0))
+                    .counselStatus(CounselStatus.COUNSEL_BEFORE)
+                    .build();
+
+            ApplyCounselResponse expectedResponse = ApplyCounselResponse.builder()
+                    .counselId(counselId)
+                    .counselFormId(counselFormId)
+                    .counselDate(newDate)
+                    .counselTime(newTime)
+                    .build();
+
+            given(counselorRepository.getCounselor(counselorId)).willReturn(counselor);
+            given(counselFormRepository.getCounselFormById(counselFormId)).willReturn(counselForm);
+            given(counselRepository.getCounselById(counselId)).willReturn(counsel);
+            given(counselRepository.save(any(Counsel.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+            given(counselMapper.toApplyCounselResponse(counselId, counselForm, newDate, newTime, counsel.getCounselor()))
+                    .willReturn(expectedResponse);
+
+            ApplyCounselResponse result = counselService.updateApplyCounsel(
+                    counselId, counselFormId, member, counselorId, newDate, newTime
+            );
+
+            assertThat(result).isEqualTo(expectedResponse);
+            assertThat(counsel.getCounselDate()).isEqualTo(newDate);
+            assertThat(counsel.getCounselTime()).isEqualTo(newTime);
+
+            then(counselRepository).should().save(counsel);
+            then(counselMapper).should()
+                    .toApplyCounselResponse(counselId, counselForm, newDate, newTime, counsel.getCounselor());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상담 일정을 변경하려고 하면 상담 정보를 찾을 수 없다는 예외가 발생")
+        void updateApplyCounsel_fail_whenCounselNotFound() {
+            Long invalidCounselId = 999L;
+
+            given(counselorRepository.getCounselor(1L)).willReturn(counselor);
+            given(counselFormRepository.getCounselFormById(1L)).willReturn(counselForm);
+            given(counselRepository.getCounselById(invalidCounselId))
+                    .willThrow(new CustomApiException(ErrorCode.COUNSEL_NOT_FOUND));
+
+            assertThatThrownBy(() -> counselService.updateApplyCounsel(
+                    invalidCounselId, 1L, member, 1L,
+                    LocalDate.of(2025, 12, 31), LocalTime.of(14, 0)
+            ))
+                    .isInstanceOf(CustomApiException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.COUNSEL_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("상담 가능 시간 조회")
+    class InquiryPossibleTimeTest {
+
+        @Test
+        @DisplayName("예약이 없는 날에는 상담사의 전체 가능 시간이 반환")
+        void inquiryPossibleTime_noReservations_returnsAllSlots() {
+            LocalDate date = LocalDate.of(2025, 12, 30);
+            List<LocalTime> allSlots = counselor.getAvailableTimeSlots();
+
+            given(counselorRepository.getCounselor(1L)).willReturn(counselor);
+            given(counselRepository.findReservedTimes(1L, date)).willReturn(List.of());
+
+            List<LocalTime> result = counselService.inquiryPossibleTime(1L, date);
+
+            assertThat(result).hasSize(allSlots.size());
+            assertThat(result).containsExactlyElementsOf(allSlots);
+        }
+
+        @Test
+        @DisplayName("이미 예약된 시간은 상담 가능 시간 목록에서 제외")
+        void inquiryPossibleTime_withReservations_excludesReservedTimes() {
+            LocalDate date = LocalDate.of(2025, 12, 30);
+            LocalTime reservedTime1 = LocalTime.of(10, 0);
+            LocalTime reservedTime2 = LocalTime.of(11, 0);
+
+            given(counselorRepository.getCounselor(1L)).willReturn(counselor);
+            given(counselRepository.findReservedTimes(1L, date))
+                    .willReturn(List.of(reservedTime1, reservedTime2));
+
+            List<LocalTime> result = counselService.inquiryPossibleTime(1L, date);
+
+            assertThat(result).doesNotContain(reservedTime1, reservedTime2);
+            assertThat(result).hasSize(counselor.getAvailableTimeSlots().size() - 2);
+        }
+
+        @Test
+        @DisplayName("해당 날짜의 모든 시간이 예약되어 있으면 빈 목록을 반환")
+        void inquiryPossibleTime_allReserved_returnsEmptyList() {
+            LocalDate date = LocalDate.of(2025, 12, 30);
+            List<LocalTime> allSlots = counselor.getAvailableTimeSlots();
+
+            given(counselorRepository.getCounselor(1L)).willReturn(counselor);
+            given(counselRepository.findReservedTimes(1L, date)).willReturn(allSlots);
+
+            List<LocalTime> result = counselService.inquiryPossibleTime(1L, date);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("상담 정보 조회")
+    class GetCounselInfoTest {
+
+        @Test
+        @DisplayName("진행 중인 상담이 없으면 NONE 상태와 함께 빈 상담 정보를 반환")
+        void getCounselInfo_whenNoCounsel_returnsNoneStatus() {
+            given(counselRepository.findByMember(member)).willReturn(Optional.empty());
+
+            CounselCombinedResponse result = counselService.getCounselInfo(member);
+
+            assertThat(result.getStatus()).isEqualTo(CounselStatus.NONE);
+            assertThat(result.getInfo()).isNull();
+
+            then(counselFormRepository).shouldHaveNoInteractions();
+            then(reviewRepository).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("진행 중인 상담이 있으면 상담 상태와 상세 정보를 함께 반환")
+        void getCounselInfo_whenCounselExists_returnsCounselInfo() {
+            LocalDate counselDate = LocalDate.of(2025, 12, 30);
+            LocalTime counselTime = LocalTime.of(10, 0);
+
+            Counsel existingCounsel = Counsel.builder()
+                    .id(1L)
+                    .member(member)
+                    .counselor(counselor)
+                    .counselForm(counselForm)
+                    .counselDate(counselDate)
+                    .counselTime(counselTime)
+                    .counselStatus(CounselStatus.COUNSEL_BEFORE)
+                    .build();
+
+            CounselInfoResponse infoResponse = CounselInfoResponse.builder()
+                    .counselId(1L)
+                    .counselorId(1L)
+                    .counselorName("테스트 상담사")
+                    .counselDate(counselDate)
+                    .counselTime(counselTime)
+                    .build();
+
+            given(counselRepository.findByMember(member)).willReturn(Optional.of(existingCounsel));
+            given(counselFormRepository.getCounselFormByMember(member)).willReturn(counselForm);
+            given(reviewRepository.findAllByCounsel_Counselor(counselor)).willReturn(List.of());
+            given(reviewRepository.existsByCounsel(existingCounsel)).willReturn(false);
+            given(counselMapper.toCounselInfoResponse(
+                    1L, counselor, counselForm, counselDate, counselTime, false, 0.0, 0
+            )).willReturn(infoResponse);
+
+            CounselCombinedResponse result = counselService.getCounselInfo(member);
+
+            assertThat(result.getStatus()).isEqualTo(CounselStatus.COUNSEL_BEFORE);
+            assertThat(result.getInfo()).isNotNull();
+            assertThat(result.getInfo().getCounselId()).isEqualTo(1L);
+            assertThat(result.getInfo().getCounselorName()).isEqualTo("테스트 상담사");
+
+            then(counselMapper).should().toCounselInfoResponse(
+                    1L, counselor, counselForm, counselDate, counselTime, false, 0.0, 0
+            );
+        }
+
+        @Test
+        @DisplayName("리뷰가 존재하면 평균 점수와 리뷰 수를 계산해 상담 정보에 반영")
+        void getCounselInfo_withReviews_calculatesAverageScore() {
+            LocalDate counselDate = LocalDate.of(2025, 12, 30);
+            LocalTime counselTime = LocalTime.of(10, 0);
+
+            Counsel existingCounsel = Counsel.builder()
+                    .id(1L)
+                    .member(member)
+                    .counselor(counselor)
+                    .counselForm(counselForm)
+                    .counselDate(counselDate)
+                    .counselTime(counselTime)
+                    .counselStatus(CounselStatus.COUNSEL_AFTER)
+                    .build();
+
+            Review mockReview1 = mock(Review.class);
+            Review mockReview2 = mock(Review.class);
+            given(mockReview1.getScore()).willReturn(4);
+            given(mockReview2.getScore()).willReturn(5);
+
+            CounselInfoResponse infoResponse = CounselInfoResponse.builder()
+                    .counselId(1L)
+                    .counselorId(1L)
+                    .counselorName("테스트 상담사")
+                    .score(4.5)
+                    .reviewCount(2)
+                    .build();
+
+            given(counselRepository.findByMember(member)).willReturn(Optional.of(existingCounsel));
+            given(counselFormRepository.getCounselFormByMember(member)).willReturn(counselForm);
+            given(reviewRepository.findAllByCounsel_Counselor(counselor))
+                    .willReturn(List.of(mockReview1, mockReview2));
+            given(reviewRepository.existsByCounsel(existingCounsel)).willReturn(true);
+            given(counselMapper.toCounselInfoResponse(
+                    1L, counselor, counselForm, counselDate, counselTime, true, 4.5, 2
+            )).willReturn(infoResponse);
+
+            CounselCombinedResponse result = counselService.getCounselInfo(member);
+
+            assertThat(result.getStatus()).isEqualTo(CounselStatus.COUNSEL_AFTER);
+            assertThat(result.getInfo().getScore()).isEqualTo(4.5);
+            assertThat(result.getInfo().getReviewCount()).isEqualTo(2);
+
+            then(counselMapper).should().toCounselInfoResponse(
+                    1L, counselor, counselForm, counselDate, counselTime, true, 4.5, 2
+            );
+        }
+    }
+}


### PR DESCRIPTION
상담 도메인 관련 테스트 코드를 추가

- 서비스 레이어 단위 테스트 작성
- 컨트롤러 레이어 슬라이스 테스트 작성
- 주요 성공/실패 시나리오 검증
