### PR TITLE
[FIX] 애플 계정 탈퇴 후 다시 회원 가입 시 이름을 받아오지 못하는 오류 수정

### DIFF
--- a/src/main/java/auctionTalk/auction/config/security/auth/CustomOAuth2UserService.java
+++ b/src/main/java/auctionTalk/auction/config/security/auth/CustomOAuth2UserService.java
@@ -33,12 +33,22 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         Map<String, Object> attributes = oAuth2User.getAttributes();
         String clientId = attributes.get(userNameAttribute).toString();
+        LoginType loginType = LoginType.from(registrationId);
 
-        Member member = memberRepository.findByClientIdAndLoginType(clientId, LoginType.from(registrationId))
+        Member member = memberRepository
+                .findByClientIdAndLoginTypeIncludingDeleted(clientId, loginType)
+                .map(existingMember -> {
+                    if (existingMember.isDeleted()) {
+                        existingMember.restore();
+                    }
+
+                    return existingMember;
+                })
                 .orElseGet(() -> {
                     String name = extractName(registrationId, attributes);
 
-                    Member newMember = authMapper.toMember(clientId, LoginType.from(registrationId));
+                    Member newMember = authMapper.toMember(clientId, loginType);
+
                     if (StringUtils.hasText(name)) {
                         newMember.updateName(name);
                     }

--- a/src/main/java/auctionTalk/auction/config/security/auth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/auctionTalk/auction/config/security/auth/OAuth2LoginSuccessHandler.java
@@ -63,7 +63,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
             String registrationId = oauthToken.getAuthorizedClientRegistrationId();
 
-            if ("apple".equals(registrationId) && !StringUtils.hasText(member.getName())) {
+            if ("apple".equals(registrationId) && canUpdateAppleName(member)) {
                 String appleName = extractAppleName(request);
 
                 if (StringUtils.hasText(appleName)) {
@@ -188,5 +188,12 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
+    }
+
+    private boolean canUpdateAppleName(Member member) {
+        return !StringUtils.hasText(member.getName())
+                || "사용자".equals(member.getName())
+                || "unknown".equalsIgnoreCase(member.getName())
+                || "null".equalsIgnoreCase(member.getName());
     }
 }

--- a/src/main/java/auctionTalk/auction/config/security/auth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/auctionTalk/auction/config/security/auth/OAuth2LoginSuccessHandler.java
@@ -114,25 +114,40 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
     private String extractAppleName(HttpServletRequest request) {
         String userJson = request.getParameter("user");
+
+        log.info("[APPLE_USER_PARAM] user={}", userJson);
+
         if (!StringUtils.hasText(userJson)) {
             return null;
         }
 
         try {
             ObjectMapper mapper = new ObjectMapper();
+
             JsonNode root = mapper.readTree(userJson);
             JsonNode nameNode = root.path("name");
 
             String firstName = nameNode.path("firstName").asText(null);
             String lastName = nameNode.path("lastName").asText(null);
 
-            if (StringUtils.hasText(firstName) && StringUtils.hasText(lastName)) {
-                return lastName + firstName; // 🇰🇷 한국식
+            log.info("[APPLE_NAME_PARSED] firstName={}, lastName={}", firstName, lastName);
+
+            StringBuilder fullName = new StringBuilder();
+
+            if (StringUtils.hasText(lastName)) {
+                fullName.append(lastName);
             }
+
+            if (StringUtils.hasText(firstName)) {
+                fullName.append(firstName);
+            }
+
+            return StringUtils.hasText(fullName.toString()) ? fullName.toString() : null;
+
         } catch (Exception e) {
-            log.warn("🍎 Apple name 파싱 실패", e);
+            log.warn("[APPLE_NAME_PARSE_FAILED] userJson={}", userJson, e);
+            return null;
         }
-        return null;
     }
 
     private String resolveRedirectUrl(HttpServletRequest request) {

--- a/src/main/java/auctionTalk/auction/domain/member/entity/Member.java
+++ b/src/main/java/auctionTalk/auction/domain/member/entity/Member.java
@@ -6,7 +6,6 @@ import lombok.*;
 import org.hibernate.annotations.Where;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity

--- a/src/main/java/auctionTalk/auction/domain/member/repository/MemberRepository.java
+++ b/src/main/java/auctionTalk/auction/domain/member/repository/MemberRepository.java
@@ -5,6 +5,8 @@ import auctionTalk.auction.domain.member.entity.Member;
 import auctionTalk.auction.global.exception.CustomApiException;
 import auctionTalk.auction.global.exception.ErrorCode;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -20,6 +22,21 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
         return member;
     }
+
+    @Query(value = """
+        SELECT *
+        FROM member
+        WHERE client_id = :clientId
+          AND login_type = :#{#loginType.name()}
+        ORDER BY 
+          CASE WHEN deleted_at IS NULL THEN 0 ELSE 1 END,
+          id DESC
+        LIMIT 1
+        """, nativeQuery = true)
+    Optional<Member> findByClientIdAndLoginTypeIncludingDeleted(
+            @Param("clientId") String clientId,
+            @Param("loginType") LoginType loginType
+    );
 
     Optional<Member> findByUsername(String username);
     Optional<Member> findByClientIdAndLoginType(String clientId, LoginType loginType);

--- a/src/main/java/auctionTalk/auction/global/common/BaseEntity.java
+++ b/src/main/java/auctionTalk/auction/global/common/BaseEntity.java
@@ -31,4 +31,12 @@ public abstract class BaseEntity {
     public void delete() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    public void restore() {
+        this.deletedAt = null;
+    }
 }


### PR DESCRIPTION
1. 애플 계정 이름 추출 로직 코드 수정
2. 계정 탈퇴 후 재 로그인 시 새로운 계정 생성 방식에서 계정 회복 방식으로 변경